### PR TITLE
feat(Search): adding print modes

### DIFF
--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -41,6 +41,18 @@ Search in all the markdown files under the "src" folder for the keywords "Table 
 > search --type f --pattern ".md$" --grep "Table of Content"
 ```
 
+Find all files with the extension ".jsx" in the "src" folder and print their content
+
+```sh
+> search --type f --pattern ".jsx$" --printMode simple src/
+```
+
+Find all files with the extension ".jsx" in the "src" folder and print their content in a Claude XML format
+
+```sh
+> search --type f --pattern ".jsx$" --printMode xml src/
+```
+
 Get help
 
 ```sh

--- a/packages/search/src/__tests__/core.test.ts
+++ b/packages/search/src/__tests__/core.test.ts
@@ -111,6 +111,57 @@ describe("when testing for utilities with logging side-effects", () => {
 		);
 	});
 
+	it("should find and print specific files based on the arguments (md, simple)", async () => {
+		const search = new Search({
+			...defaultFlags,
+			foldersBlacklist: /node_modules/gi,
+			boring: true,
+			path: `${process.cwd()}`,
+			pattern: ".md",
+			short: true,
+			stats: true,
+			type: "f",
+			printMode: "simple",
+		});
+		await search.start();
+		expect(mockLog).toHaveBeenCalledWith(
+			expect.stringContaining("---\n./README.md\n---"),
+		);
+		expect(mockLog).toHaveBeenCalledWith(
+			expect.stringContaining("Search is a command line tool that can"),
+		);
+	});
+
+	it("should find and print a specific file based on the arguments (xml)", async () => {
+		const search = new Search({
+			...defaultFlags,
+			foldersBlacklist: /node_modules/gi,
+			boring: true,
+			path: `${process.cwd()}`,
+			pattern: "README.md",
+			short: true,
+			stats: true,
+			type: "f",
+			printMode: "xml",
+		});
+		await search.start();
+		expect(mockLog).toHaveBeenCalledWith(
+			expect.stringContaining("<documents>"),
+		);
+		expect(mockLog).toHaveBeenCalledWith(
+			expect.stringContaining('<document index="1">'),
+		);
+		expect(mockLog).toHaveBeenCalledWith(
+			expect.stringContaining("<source>./README.md</source>"),
+		);
+		expect(mockLog).toHaveBeenCalledWith(
+			expect.stringContaining("<document_content>"),
+		);
+		expect(mockLog).toHaveBeenCalledWith(
+			expect.stringContaining("</documents>"),
+		);
+	});
+
 	it("should find and list all files based on the arguments", async () => {
 		const search = new Search({
 			...defaultFlags,

--- a/packages/search/src/core.ts
+++ b/packages/search/src/core.ts
@@ -280,18 +280,6 @@ export class Search {
 					node.type === STR_TYPE_DIRECTORY) ||
 				this.type === STR_TYPE_BOTH
 			) {
-				// // If printMode is enabled and this is a file, print its content
-				// if (this.printMode && node.type === STR_TYPE_FILE) {
-				// 	const relativePath = relative(process.cwd(), node.name);
-				// 	logger.log(`---\n./${relativePath}\n---`);
-				// 	const content = await this.readFileContent(node.name);
-				// 	logger.log(content);
-				// 	if (node !== this.nodesList[this.nodesList.length - 1]) {
-				// 		logger.log("");
-				// 	}
-				// 	continue;
-				// }
-
 				let list: {
 						group?: string;
 						mdate?: string;

--- a/packages/search/src/core.ts
+++ b/packages/search/src/core.ts
@@ -19,6 +19,7 @@ import plur from "plur";
 
 const lstatAsync = promisify(fs.lstat);
 const readdirAsync = promisify(fs.readdir);
+const readFileAsync = promisify(fs.readFile);
 const perf = new Performance();
 const logger = new Logger({
 	boring: process.env.NODE_ENV === "test",
@@ -41,6 +42,7 @@ export class Search {
 	totalFileScanned?: number;
 	type?: string;
 	ignoreExtensions?: string[];
+	printMode?: string;
 
 	constructor({
 		boring,
@@ -55,6 +57,7 @@ export class Search {
 		stats,
 		type,
 		ignore,
+		printMode,
 	}: {
 		boring?: boolean;
 		command?: string;
@@ -68,6 +71,7 @@ export class Search {
 		stats?: boolean;
 		type?: string;
 		ignore?: string[];
+		printMode?: string;
 	}) {
 		this.path = path;
 		this.rePattern = pattern
@@ -87,6 +91,7 @@ export class Search {
 		this.totalFileFound = 0;
 		this.command = command ? command.trim() : undefined;
 		this.ignoreExtensions = ignore.map((ext) => ext.toLowerCase());
+		this.printMode = printMode;
 		try {
 			this.grep = grep ? new RegExp(grep, ignoreCase ? "gi" : "g") : undefined;
 		} catch (error) {
@@ -201,6 +206,52 @@ export class Search {
 		}
 	}
 
+	async readFileContent(filePath: string): Promise<string> {
+		try {
+			const content = await readFileAsync(filePath, "utf8");
+			return content;
+		} catch (error) {
+			/* istanbul ignore next */
+			return `Error reading file: ${error.message}`;
+		}
+	}
+
+	async printFilesContent() {
+		const fileNodes = this.nodesList.filter(
+			(node) => node.type === STR_TYPE_FILE,
+		);
+
+		if (this.printMode === "simple") {
+			for (const node of fileNodes) {
+				const relativePath = relative(process.cwd(), node.name);
+				logger.log(`---\n./${relativePath}\n---`);
+				const content = await this.readFileContent(node.name);
+				logger.log(content);
+				// adding a new line after each file content except the last one
+				if (node !== fileNodes[fileNodes.length - 1]) {
+					logger.log("");
+				}
+			}
+		} else if (this.printMode === "xml") {
+			logger.log("<documents>");
+
+			for (let i = 0; i < fileNodes.length; i++) {
+				const node = fileNodes[i];
+				const relativePath = relative(process.cwd(), node.name);
+				const content = await this.readFileContent(node.name);
+
+				logger.log(`<document index="${i + 1}">`);
+				logger.log(`<source>./${relativePath}</source>`);
+				logger.log("<document_content>");
+				logger.log(content);
+				logger.log("</document_content>");
+				logger.log("</document>");
+			}
+
+			logger.log("</documents>");
+		}
+	}
+
 	async postProcessResults() {
 		/* istanbul ignore if */
 		if (!this.boring) {
@@ -216,6 +267,12 @@ export class Search {
 			this.totalFileFound = 0;
 		}
 
+		// If printMode is enabled, handle file content printing and return
+		if (this.printMode && ["simple", "xml"].includes(this.printMode)) {
+			await this.printFilesContent();
+			return;
+		}
+
 		for (const node of this.nodesList) {
 			if (
 				(this.type === STR_TYPE_FILE && node.type === STR_TYPE_FILE) ||
@@ -223,6 +280,18 @@ export class Search {
 					node.type === STR_TYPE_DIRECTORY) ||
 				this.type === STR_TYPE_BOTH
 			) {
+				// // If printMode is enabled and this is a file, print its content
+				// if (this.printMode && node.type === STR_TYPE_FILE) {
+				// 	const relativePath = relative(process.cwd(), node.name);
+				// 	logger.log(`---\n./${relativePath}\n---`);
+				// 	const content = await this.readFileContent(node.name);
+				// 	logger.log(content);
+				// 	if (node !== this.nodesList[this.nodesList.length - 1]) {
+				// 		logger.log("");
+				// 	}
+				// 	continue;
+				// }
+
 				let list: {
 						group?: string;
 						mdate?: string;

--- a/packages/search/src/parse.ts
+++ b/packages/search/src/parse.ts
@@ -1,3 +1,4 @@
+import { print } from "kleur/colors";
 import { defaultFlags, defaultParameters } from "./defaults.js";
 
 import { parser } from "@node-cli/parser";
@@ -11,6 +12,7 @@ export type Flags = {
 	grep?: string;
 	type?: string;
 	ignore?: string[];
+	printMode?: string;
 };
 
 export type Parameters = {
@@ -105,6 +107,11 @@ export const config: Configuration = parser({
 			description: "Ignore files extensions",
 			type: "string",
 			isMultiple: true,
+		},
+		printMode: {
+			shortFlag: "P",
+			description: "Print mode (simple or xml)",
+			type: "string",
 		},
 	},
 	parameters: {


### PR DESCRIPTION
This pull request introduces a new feature to the `Search` class that allows printing the content of found files in different formats. The most important changes include the addition of the `printMode` option, updates to the `Search` class to handle this option, and corresponding test cases.

New feature for printing file contents:

* [`packages/search/src/core.ts`](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R45): Added `printMode` option to the `Search` class, implemented methods to read and print file contents in both simple and XML formats, and integrated these methods into the search process. [[1]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R45) [[2]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R60) [[3]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R74) [[4]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R94) [[5]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R209-R254) [[6]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R270-R294)

* [`packages/search/src/parse.ts`](diffhunk://#diff-8cf4cd59eca0473f611c8749818418ff2fad8120626ca4c9acee13a43c9f5913R1): Updated the `Flags` type and configuration to include the `printMode` option. [[1]](diffhunk://#diff-8cf4cd59eca0473f611c8749818418ff2fad8120626ca4c9acee13a43c9f5913R1) [[2]](diffhunk://#diff-8cf4cd59eca0473f611c8749818418ff2fad8120626ca4c9acee13a43c9f5913R15) [[3]](diffhunk://#diff-8cf4cd59eca0473f611c8749818418ff2fad8120626ca4c9acee13a43c9f5913R111-R115)

Documentation:

* [`packages/search/README.md`](diffhunk://#diff-2fd0e05955711d59430fb1b196629b6cf08c771078b34294abbc962cdf79c8f8R44-R55): Added examples demonstrating how to use the new `printMode` option to print file contents in simple and XML formats.

Test cases:

* [`packages/search/src/__tests__/core.test.ts`](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809R114-R164): Added test cases to verify the functionality of the `printMode` option for both simple and XML formats.