### PR TITLE
fix(Search): allowing search to be called programmatically

### DIFF
--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -6,7 +6,7 @@
 	"description": "Search for files in a directory",
 	"type": "module",
 	"types": "./dist/index.d.ts",
-	"exports": "./dist/search.js",
+	"exports": "./dist/core.js",
 	"bin": "dist/search.js",
 	"files": [
 		"dist"


### PR DESCRIPTION
This pull request includes a change to the `packages/search/package.json` file to update the exported module. The most important change is:

* Changed the `"exports"` field to point to `./dist/core.js` instead of `./dist/search.js`.