### PR TITLE
feat: allowing to return data instead of print to stdio

### DIFF
--- a/packages/search/src/__tests__/core.test.ts
+++ b/packages/search/src/__tests__/core.test.ts
@@ -355,3 +355,38 @@ describe("when testing for utilities with logging side-effects", () => {
 		expect(mockExit).toHaveBeenCalledWith(1);
 	});
 });
+
+describe("when testing for utilities with NO logging side-effects", () => {
+	it("should find and print specific files based on the arguments (md, simple)", async () => {
+		const search = new Search({
+			...defaultFlags,
+			foldersBlacklist: /node_modules/gi,
+			boring: true,
+			path: `${process.cwd()}`,
+			pattern: ".md",
+			short: true,
+			stats: false,
+			type: "f",
+			printMode: "simple",
+		});
+		const res = await search.start(true);
+		expect(res).toContain("README.md\n---");
+		expect(res).toContain("CHANGELOG.md\n---");
+	});
+
+	it("should find and print a specific file based on the arguments (xml)", async () => {
+		const search = new Search({
+			...defaultFlags,
+			foldersBlacklist: /node_modules/gi,
+			boring: true,
+			path: `${process.cwd()}`,
+			pattern: "README.md",
+			short: true,
+			stats: false,
+			type: "f",
+			printMode: "xml",
+		});
+		const res = await search.start(true);
+		expect(res).toContain("<source>./README.md</source>");
+	});
+});


### PR DESCRIPTION
This pull request introduces new tests for the `Search` class and modifies its methods to optionally return results instead of logging them directly. The changes enhance the flexibility and testability of the search functionality.

### New Tests:
* Added tests for the `Search` class to verify its behavior when there are no logging side-effects. (`packages/search/src/__tests__/core.test.ts`)

### Method Enhancements:
* Modified the `start` method in the `Search` class to accept a `returnResults` parameter, enabling it to return results instead of logging them. (`packages/search/src/core.ts`)
* Updated the `printFilesContent` method to conditionally return results based on the `returnResults` parameter. (`packages/search/src/core.ts`)
* Adjusted the `postProcessResults` method to handle the `returnResults` parameter and return results if specified. (`packages/search/src/core.ts`) [[1]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L281-R313) [[2]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L298-R330)