### PR TITLE
fix(Search): relative path for file/dir name is invalid

### DIFF
--- a/packages/search/src/core.ts
+++ b/packages/search/src/core.ts
@@ -240,7 +240,7 @@ export class Search {
 		let results = "";
 		if (this.printMode === "simple") {
 			for (const node of fileNodes) {
-				const relativePath = relative(process.cwd(), node.name);
+				const relativePath = relative(this.path, node.name);
 				if (returnResults) {
 					results += `---\n./${relativePath}\n---\n`;
 				} else {
@@ -270,7 +270,7 @@ export class Search {
 
 			for (let i = 0; i < fileNodes.length; i++) {
 				const node = fileNodes[i];
-				const relativePath = relative(process.cwd(), node.name);
+				const relativePath = relative(this.path, node.name);
 				const content = await this.readFileContent(node.name);
 
 				if (returnResults) {
@@ -360,7 +360,7 @@ export class Search {
 				}
 
 				const color = node.type === STR_TYPE_FILE ? kleur.gray : kleur.blue;
-				name = relative(process.cwd(), node.name);
+				name = relative(this.path, node.name);
 
 				if (node.match) {
 					const matchStr = String(node.match); // Ensure match is a string


### PR DESCRIPTION
This pull request includes changes to the `Search` class in the `packages/search/src/core.ts` file. The main focus of the changes is to improve the handling of relative paths by using the `this.path` property instead of `process.cwd()`.

Improvements to relative path handling:

* Modified the calculation of `relativePath` to use `this.path` instead of `process.cwd()` in the `printMode === "simple"` block.
* Updated the calculation of `relativePath` to use `this.path` instead of `process.cwd()` in the loop iterating over `fileNodes`.
* Changed the assignment of `name` to use `relative(this.path, node.name)` instead of `relative(process.cwd(), node.name)` when determining the color of the node.