### PR TITLE
fix(Search): in printMode binary files content should not be displayed

### DIFF
--- a/packages/search/src/core.ts
+++ b/packages/search/src/core.ts
@@ -129,6 +129,75 @@ export class Search {
 		return value[0] !== ".";
 	}
 
+	isBinaryFileExtension(filePath: string): boolean {
+		const ext = extname(filePath).toLowerCase().replace(/^\./, "");
+
+		// If there's no extension, assume it's binary
+		/* istanbul ignore if */
+		if (!ext) {
+			return true;
+		}
+
+		const binaryExtensions = [
+			// Executables and compiled code
+			"exe",
+			"dll",
+			"so",
+			"dylib",
+			"bin",
+			"obj",
+			"o",
+			// Compressed files
+			"zip",
+			"tar",
+			"gz",
+			"rar",
+			"7z",
+			"jar",
+			"war",
+			// Media files
+			"jpg",
+			"jpeg",
+			"png",
+			"gif",
+			"bmp",
+			"ico",
+			"tif",
+			"tiff",
+			"mp3",
+			"mp4",
+			"avi",
+			"mov",
+			"wmv",
+			"flv",
+			"wav",
+			"ogg",
+			// Document formats
+			"pdf",
+			"doc",
+			"docx",
+			"xls",
+			"xlsx",
+			"ppt",
+			"pptx",
+			// Database files
+			"db",
+			"sqlite",
+			"mdb",
+			// Other binary formats
+			"class",
+			"pyc",
+			"pyd",
+			"pyo",
+			"woff",
+			"woff2",
+			"ttf",
+			"otf",
+		];
+
+		return binaryExtensions.includes(ext);
+	}
+
 	async start(returnResults = false) {
 		if (this.displayStats) {
 			perf.start();
@@ -224,6 +293,11 @@ export class Search {
 
 	async readFileContent(filePath: string): Promise<string> {
 		try {
+			// Check if it's a known binary extension
+			/* istanbul ignore if */
+			if (this.isBinaryFileExtension(filePath)) {
+				return "[Binary file]";
+			}
 			const content = await readFileAsync(filePath, "utf8");
 			return content;
 		} catch (error) {


### PR DESCRIPTION
This pull request includes changes to the `Search` class in the `packages/search/src/core.ts` file to handle binary file extensions more effectively. The most important changes include adding a new method to identify binary file extensions and updating the file reading logic to account for binary files.

Enhancements to binary file handling:

* [`packages/search/src/core.ts`](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R132-R200): Added the `isBinaryFileExtension` method to determine if a file extension corresponds to a binary file.
* [`packages/search/src/core.ts`](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R296-R300): Modified the `readFileContent` method to return "[Binary file]" for known binary file extensions, preventing attempts to read them as text.