### PR TITLE
fix(Search)!: renamed ignore into ignoreExtension

### DIFF
--- a/packages/search/src/__tests__/core.test.ts
+++ b/packages/search/src/__tests__/core.test.ts
@@ -192,7 +192,7 @@ describe("when testing for utilities with logging side-effects", () => {
 			short: true,
 			stats: true,
 			type: "f",
-			ignore: ["json"],
+			ignoreExtension: ["json"],
 		});
 		await search.start();
 		expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("Duration: "));

--- a/packages/search/src/core.ts
+++ b/packages/search/src/core.ts
@@ -59,7 +59,7 @@ export class Search {
 		pattern,
 		stats,
 		type,
-		ignore,
+		ignoreExtension,
 		printMode,
 		ignoreGitIgnore,
 	}: {
@@ -74,7 +74,7 @@ export class Search {
 		pattern?: string;
 		stats?: boolean;
 		type?: string;
-		ignore?: string[];
+		ignoreExtension?: string[];
 		printMode?: string;
 		ignoreGitIgnore?: boolean;
 	}) {
@@ -95,7 +95,7 @@ export class Search {
 		this.totalDirFound = 0;
 		this.totalFileFound = 0;
 		this.command = command ? command.trim() : undefined;
-		this.ignoreExtensions = ignore.map((ext) => ext.toLowerCase());
+		this.ignoreExtensions = ignoreExtension.map((ext) => ext.toLowerCase());
 		this.printMode = printMode;
 		this.ignoreGitIgnore = ignoreGitIgnore;
 		this.gitIgnoreHandler = new GitIgnoreHandler();

--- a/packages/search/src/defaults.ts
+++ b/packages/search/src/defaults.ts
@@ -4,7 +4,7 @@ export const defaultFlags = {
 	ignoreCase: false,
 	short: false,
 	stats: false,
-	ignore: [],
+	ignoreExtension: [],
 	ignoreGitIgnore: false,
 };
 

--- a/packages/search/src/parse.ts
+++ b/packages/search/src/parse.ts
@@ -102,7 +102,7 @@ export const config: Configuration = parser({
 			description: "Output the current version",
 			type: "boolean",
 		},
-		ignore: {
+		ignoreExtension: {
 			shortFlag: "I",
 			description: "Ignore files extensions",
 			type: "string",


### PR DESCRIPTION
This pull request includes several changes to the `packages/search` module to rename the `ignore` parameter to `ignoreExtension` for improved clarity and consistency. The most important changes include updates to the `Search` class, test files, default flags, and configuration parsing.

Changes to `Search` class:

* [`packages/search/src/core.ts`](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L62-R62): Renamed the `ignore` parameter to `ignoreExtension` in multiple locations, including the constructor and method signatures. [[1]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L62-R62) [[2]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L77-R77) [[3]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L98-R98)

Updates to test files:

* [`packages/search/src/__tests__/core.test.ts`](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L195-R195): Updated the test case to use `ignoreExtension` instead of `ignore`.

Default flags update:

* [`packages/search/src/defaults.ts`](diffhunk://#diff-352c4dfa6c62f2ce8746db757958093700791c36ee1d161057f118e83edb2980L7-R7): Changed the default flag from `ignore` to `ignoreExtension`.

Configuration parsing update:

* [`packages/search/src/parse.ts`](diffhunk://#diff-8cf4cd59eca0473f611c8749818418ff2fad8120626ca4c9acee13a43c9f5913L105-R105): Renamed the configuration option from `ignore` to `ignoreExtension` to match the new parameter name.