### PR TITLE
feat(Search): adding ignoreFile option

### DIFF
--- a/packages/search/src/__tests__/core.test.ts
+++ b/packages/search/src/__tests__/core.test.ts
@@ -183,6 +183,30 @@ describe("when testing for utilities with logging side-effects", () => {
 		);
 	});
 
+	it("should find and list all files based on the arguments including ignoreFile", async () => {
+		const search = new Search({
+			...defaultFlags,
+			foldersBlacklist: /node_modules/gi,
+			boring: true,
+			path: `${process.cwd()}`,
+			short: true,
+			stats: true,
+			type: "f",
+			ignoreFile: ["README.md"],
+		});
+		await search.start();
+		expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("Duration: "));
+		expect(mockLog).not.toHaveBeenCalledWith(
+			expect.stringContaining("README.md"),
+		);
+		expect(mockLog).toHaveBeenCalledWith(
+			expect.stringContaining("CHANGELOG.md"),
+		);
+		expect(mockLog).toHaveBeenCalledWith(
+			expect.stringContaining("package.json"),
+		);
+	});
+
 	it("should find and list all files expect json ones", async () => {
 		const search = new Search({
 			...defaultFlags,

--- a/packages/search/src/core.ts
+++ b/packages/search/src/core.ts
@@ -44,6 +44,7 @@ export class Search {
 	totalFileScanned?: number;
 	type?: string;
 	ignoreExtensions?: string[];
+	ignoreFiles?: string[];
 	printMode?: string;
 	gitIgnoreHandler: GitIgnoreHandler;
 	ignoreGitIgnore?: boolean;
@@ -61,6 +62,7 @@ export class Search {
 		stats,
 		type,
 		ignoreExtension,
+		ignoreFile,
 		printMode,
 		ignoreGitIgnore,
 	}: {
@@ -76,6 +78,7 @@ export class Search {
 		stats?: boolean;
 		type?: string;
 		ignoreExtension?: string[];
+		ignoreFile?: string[];
 		printMode?: string;
 		ignoreGitIgnore?: boolean;
 	}) {
@@ -97,6 +100,7 @@ export class Search {
 		this.totalFileFound = 0;
 		this.command = command ? command.trim() : undefined;
 		this.ignoreExtensions = ignoreExtension.map((ext) => ext.toLowerCase());
+		this.ignoreFiles = ignoreFile || [];
 		this.printMode = printMode;
 		this.ignoreGitIgnore = ignoreGitIgnore;
 		this.gitIgnoreHandler = new GitIgnoreHandler();
@@ -115,6 +119,13 @@ export class Search {
 	}
 
 	shouldIgnoreFile(filePath: string) {
+		// First check if the file is in the ignoreFiles list
+		const filename = basename(filePath);
+		if (this.ignoreFiles && this.ignoreFiles.includes(filename)) {
+			return true;
+		}
+
+		// Then check if the extension should be ignored
 		if (!this.ignoreExtensions || this.ignoreExtensions.length === 0) {
 			return false;
 		}

--- a/packages/search/src/parse.ts
+++ b/packages/search/src/parse.ts
@@ -107,6 +107,12 @@ export const config: Configuration = parser({
 			type: "string",
 			isMultiple: true,
 		},
+		ignoreFile: {
+			shortFlag: "F",
+			description: "Ignore files names",
+			type: "string",
+			isMultiple: true,
+		},
 		printMode: {
 			shortFlag: "P",
 			description: "Print mode (simple or xml)",


### PR DESCRIPTION
This pull request introduces a new feature to the `Search` class that allows users to specify files to be ignored during the search process. The most important changes include adding the `ignoreFile` option to the `Search` class and updating the test cases to verify this new functionality.

### New Feature: Ignore Specific Files

* [`packages/search/src/core.ts`](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R47): Added the `ignoreFile` option to the `Search` class constructor and implemented logic to ignore specified files in the `shouldIgnoreFile` method. [[1]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R47) [[2]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R65) [[3]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R81) [[4]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R103) [[5]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R122-R128)
* [`packages/search/src/parse.ts`](diffhunk://#diff-8cf4cd59eca0473f611c8749818418ff2fad8120626ca4c9acee13a43c9f5913R110-R115): Added the `ignoreFile` configuration option to the parser with a short flag `-F` and description.

### Test Updates

* [`packages/search/src/__tests__/core.test.ts`](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809R186-R209): Added a new test case to verify that the `ignoreFile` option correctly excludes specified files from the search results.