### PR TITLE
fix(Search): better ignoreExtension option allowing "min.js" pattern

### DIFF
--- a/packages/search/src/__tests__/core.test.ts
+++ b/packages/search/src/__tests__/core.test.ts
@@ -229,6 +229,25 @@ describe("when testing for utilities with logging side-effects", () => {
 		);
 	});
 
+	it("should find and list all js files expect test ones", async () => {
+		const search = new Search({
+			...defaultFlags,
+			foldersBlacklist: /node_modules/gi,
+			boring: true,
+			path: `${process.cwd()}`,
+			short: true,
+			stats: true,
+			type: "f",
+			ignoreExtension: ["test.ts"],
+		});
+		await search.start();
+		expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("Duration: "));
+		expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("core.ts"));
+		expect(mockLog).not.toHaveBeenCalledWith(
+			expect.stringContaining("core.test.js"),
+		);
+	});
+
 	it("should find and list a hidden file based on the arguments", async () => {
 		const search = new Search({
 			...defaultFlags,

--- a/packages/search/src/core.ts
+++ b/packages/search/src/core.ts
@@ -131,7 +131,26 @@ export class Search {
 		}
 
 		const extension = extname(filePath).toLowerCase().replace(/^\./, "");
-		return this.ignoreExtensions.includes(extension);
+
+		// Check for exact extension match
+		if (this.ignoreExtensions.includes(extension)) {
+			return true;
+		}
+
+		// Check for complex patterns like "min.js"
+		for (const pattern of this.ignoreExtensions) {
+			// Skip patterns that don't contain a dot
+			if (!pattern.includes(".")) {
+				continue;
+			}
+
+			// Check if the filename ends with the pattern
+			if (filename.toLowerCase().endsWith(`.${pattern}`)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	filterHidden(value: string[] | string) {


### PR DESCRIPTION
This pull request includes changes to the `Search` class and its associated tests to enhance the file search functionality and improve test coverage. The most important changes include adding a new test case to ensure non-test JavaScript files are listed and updating the file extension filtering logic to support complex patterns.

Enhancements to file search functionality:

* [`packages/search/src/core.ts`](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L134-R153): Updated the `ignoreExtensions` method to check for complex patterns like "min.js" in addition to exact extension matches.

Improvements to test coverage:

* [`packages/search/src/__tests__/core.test.ts`](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809R232-R250): Added a new test case to ensure that all JavaScript files except test files are listed correctly and that logging side-effects are verified.