### PR TITLE
feat(Search)!: replacing hidden option foldersBlacklist with ignoreFolder

### DIFF
--- a/packages/search/src/__tests__/core.test.ts
+++ b/packages/search/src/__tests__/core.test.ts
@@ -62,7 +62,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should find and list a specific folder based on the arguments", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			pattern: "__tests__$",
@@ -77,7 +76,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should find and list details for a folder based on the arguments", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			pattern: "__tests__$",
@@ -92,10 +90,42 @@ describe("when testing for utilities with logging side-effects", () => {
 		);
 	});
 
+	it("should find and list all folders based on the arguments", async () => {
+		const search = new Search({
+			...defaultFlags,
+			boring: true,
+			path: `${process.cwd()}`,
+			short: true,
+			stats: true,
+			type: "d",
+		});
+		await search.start();
+		expect(mockLog).toHaveBeenCalledWith(expect.stringContaining("src"));
+		expect(mockLog).not.toHaveBeenCalledWith(
+			expect.stringContaining("node_modules"),
+		);
+	});
+
+	it("should find and list all folders based on the arguments (ignore src)", async () => {
+		const search = new Search({
+			...defaultFlags,
+			boring: true,
+			path: `${process.cwd()}`,
+			short: true,
+			stats: true,
+			type: "d",
+			ignoreFolder: ["src"],
+		});
+		await search.start();
+		expect(mockLog).not.toHaveBeenCalledWith(expect.stringContaining("src"));
+		expect(mockLog).not.toHaveBeenCalledWith(
+			expect.stringContaining("node_modules"),
+		);
+	});
+
 	it("should find and list a specific file based on the arguments", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			pattern: "README.md",
@@ -114,7 +144,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should find and print specific files based on the arguments (md, simple)", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			pattern: ".md",
@@ -135,7 +164,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should find and print a specific file based on the arguments (xml)", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			pattern: "README.md",
@@ -165,7 +193,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should find and list all files based on the arguments", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			short: true,
@@ -186,7 +213,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should find and list all files based on the arguments including ignoreFile", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			short: true,
@@ -210,7 +236,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should find and list all files expect json ones", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			short: true,
@@ -232,7 +257,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should find and list all js files expect test ones", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			short: true,
@@ -251,7 +275,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should find and list a hidden file based on the arguments", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			dot: true,
 			path: `${process.cwd()}`,
@@ -268,7 +291,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should find and list files while ignoring the case based on the arguments", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			ignoreCase: true,
 			path: `${process.cwd()}`,
@@ -286,7 +308,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should find and list all files and directories when there is no patterns or types provided", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			short: true,
@@ -302,7 +323,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should run a command on the file that matches the pattern", async () => {
 		const config = {
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			pattern: "package.json",
@@ -322,7 +342,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should run a command on the file that matches the pattern but does not return anything", async () => {
 		const config = {
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			pattern: "package.json",
@@ -342,7 +361,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should grep some text on the file that matches the pattern", async () => {
 		const config = {
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			pattern: "README.md",
@@ -365,7 +383,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should grep some text on the file that matches the pattern", async () => {
 		const config = {
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			ignoreCase: true,
 			path: `${process.cwd()}`,
@@ -383,7 +400,6 @@ describe("when testing for utilities with logging side-effects", () => {
 	it("should exit in error if the grep pattern is invalid", async () => {
 		const config = {
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			pattern: "package.json",
@@ -403,7 +419,6 @@ describe("when testing for utilities with NO logging side-effects", () => {
 	it("should find and print specific files based on the arguments (md, simple)", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			pattern: ".md",
@@ -420,7 +435,6 @@ describe("when testing for utilities with NO logging side-effects", () => {
 	it("should find and print a specific file based on the arguments (xml)", async () => {
 		const search = new Search({
 			...defaultFlags,
-			foldersBlacklist: /node_modules/gi,
 			boring: true,
 			path: `${process.cwd()}`,
 			pattern: "README.md",

--- a/packages/search/src/defaults.ts
+++ b/packages/search/src/defaults.ts
@@ -4,7 +4,6 @@ export const defaultFlags = {
 	ignoreCase: false,
 	short: false,
 	stats: false,
-	ignoreExtension: [],
 	ignoreGitIgnore: false,
 };
 

--- a/packages/search/src/parse.ts
+++ b/packages/search/src/parse.ts
@@ -103,13 +103,19 @@ export const config: Configuration = parser({
 		},
 		ignoreExtension: {
 			shortFlag: "I",
-			description: "Ignore files extensions",
+			description: "Ignore files extension, can be used multiple times",
 			type: "string",
 			isMultiple: true,
 		},
 		ignoreFile: {
 			shortFlag: "F",
-			description: "Ignore files names",
+			description: "Ignore files name, can be used multiple times",
+			type: "string",
+			isMultiple: true,
+		},
+		ignoreFolder: {
+			shortFlag: "D",
+			description: "Ignore folders name, can be used multiple times",
 			type: "string",
 			isMultiple: true,
 		},

--- a/packages/search/src/search.ts
+++ b/packages/search/src/search.ts
@@ -29,7 +29,6 @@ if (config.flags.grep) {
 const search = new Search({
 	...config.flags,
 	path: customPath,
-	foldersBlacklist: /node_modules/gi,
 });
 
 await search.start();


### PR DESCRIPTION
BREAKING CHANGE: foldersBlacklist is not available anymore

This pull request includes significant updates to the `Search` class and its associated tests. The main changes involve replacing the `foldersBlacklist` property with a new `ignoreFolder` property and updating the test cases accordingly.

### Updates to `Search` class:

* Removed the `foldersBlacklist` property and added the `ignoreFolder` property to the `Search` class. (`packages/search/src/core.ts`) [[1]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L36) [[2]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R47) [[3]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L56) [[4]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R65-L72) [[5]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R81)
* Updated the constructor to initialize `ignoreFolders` and modified the `shouldIgnoreFolder` method to check for exact folder name matches. (`packages/search/src/core.ts`)
* Replaced usage of `foldersBlacklist` with `shouldIgnoreFolder` method in the directory scanning logic. (`packages/search/src/core.ts`)

### Test case updates:

* Removed `foldersBlacklist` from various test cases and added two new test cases to verify the functionality of the `ignoreFolder` property. (`packages/search/src/__tests__/core.test.ts`) [[1]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L65) [[2]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L80) [[3]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809R93-L98) [[4]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L117) [[5]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L138) [[6]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L168) [[7]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L189) [[8]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L213) [[9]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L235) [[10]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L254) [[11]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L271) [[12]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L289) [[13]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L305) [[14]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L325) [[15]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L345) [[16]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L368) [[17]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L386) [[18]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L406) [[19]](diffhunk://#diff-59b237887fec3a41fc389c87f456ef5e741b306968c7f14527b1471e8c9c9809L423)

### Configuration updates:

* Added `ignoreFolder` to the `defaultFlags` and `config` to support the new property. (`packages/search/src/defaults.ts`, `packages/search/src/parse.ts`) [[1]](diffhunk://#diff-352c4dfa6c62f2ce8746db757958093700791c36ee1d161057f118e83edb2980L7) [[2]](diffhunk://#diff-8cf4cd59eca0473f611c8749818418ff2fad8120626ca4c9acee13a43c9f5913L106-R118)

### Search initialization update:

* Removed the `foldersBlacklist` initialization from the `search.ts` file. (`packages/search/src/search.ts`)