### PR TITLE
fix(Search): using logger in memory capabilities

### DIFF
--- a/packages/search/src/core.ts
+++ b/packages/search/src/core.ts
@@ -408,7 +408,9 @@ export class Search {
 				logger.log("</documents>");
 			}
 		}
-		return loggerInMemory.getMemoryLogs();
+		const results = returnResults ? loggerInMemory.getMemoryLogs() : undefined;
+		loggerInMemory.clearMemoryLogs();
+		return results;
 	}
 
 	async shouldIgnoreByGitIgnore(


### PR DESCRIPTION
This pull request includes changes to the `Search` class in the `packages/search/src/core.ts` file to improve logging and refactor code. The most important changes include the introduction of an in-memory logger, replacing string concatenations with logger calls, and moving a logging condition to a different part of the code.

Improvements to logging:

* Introduced a new in-memory logger instance `loggerInMemory` to store logs in memory.
* Replaced string concatenations with calls to `loggerInMemory.log` to log file contents and XML elements. [[1]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L350-R378) [[2]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L387-R394) [[3]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L404-R411)

Code refactoring:

* Removed the `results` variable and returned the logs from `loggerInMemory` using `getMemoryLogs` method.
* Moved the logging condition `if (!this.boring)` to a different part of the `postProcessResults` method. [[1]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423L424-L428) [[2]](diffhunk://#diff-56d4c8e520b0a5ba971ae0c61c1fe06f13f6556d3e3fefed3cb51ed8673cc423R440-R444)