### PR TITLE
fix: align JSDoc closing delimiter formatting

### DIFF
--- a/packages/comments/src/__tests__/lib.test.ts
+++ b/packages/comments/src/__tests__/lib.test.ts
@@ -111,9 +111,13 @@ describe("parseAndTransformComments", () => {
 		expect(out).toMatch(/Overview:/);
 		// Visually indented code line kept as-is (no extra wrapping collapse).
 		expect(out).toMatch(/const\s{3}x = 1;/);
-		// Trailing blank before closing is optional after recent trimming change.
-		// (we only keep it when multiple paragraphs exist). Assert closing exists.
-		expect(/\n\*\/$/.test(out)).toBe(true);
+		/**
+		 * Trailing blank before closing is optional after recent trimming change. (we
+		 * only keep it when multiple paragraphs exist). Assert closing exists.
+		 * Closing delimiter should be on its own line; allow optional leading
+		 * space(s).
+		 */
+		expect(/\n\s*\*\/$/.test(out)).toBe(true);
 		// Numeric list lines preserved.
 		expect(out).toMatch(/1\. first/);
 		expect(out).toMatch(/2\. second/);
@@ -272,7 +276,7 @@ describe("parseAndTransformComments", () => {
 			mergeLineComments: true,
 		}).transformed;
 		// Expect merged into a JSDoc immediately after the statement.
-		const re = /compute\(\);\n\/\*\*[\s\S]*?\n\*\//;
+		const re = /compute\(\);\n\/\*\*[\s\S]*?\n\s*\*\//;
 		expect(re.test(out)).toBe(true);
 		// Ensure only one sentence-final period appended (present on final 'list.'
 		// already).

--- a/packages/comments/src/lib.ts
+++ b/packages/comments/src/lib.ts
@@ -262,7 +262,10 @@ function buildJsDoc(indent: string, rawBody: string, width: number): string {
 		para.push(trimmed);
 	}
 	flush();
-	return `${indent}/**\n${out.join("\n")}\n${indent}*/`;
+	// Style: ensure a space precedes the closing */ for consistency with blocks
+	// generated elsewhere in this tool (merged line comment groups). Previously
+	// we emitted `${indent}*/` which produced an off-by-one visual alignment.
+	return `${indent}/**\n${out.join("\n")}\n${indent} */`;
 }
 
 function reflowJsDocBlocks(

--- a/packages/search/src/__tests__/minifiers.test.ts
+++ b/packages/search/src/__tests__/minifiers.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, test } from "vitest";
+
 import {
 	minifyCss,
 	minifyFileContent,
@@ -179,14 +181,14 @@ describe("when testing for minifiers utilities with no logging side-effects", ()
       /**
        * @param {string} name - The name parameter
        * @returns {string} A greeting message
-      */
+       */
       function greet(name) {
         return 'Hello, ' + name;
       }
 
       /**
        * This is not an important comment.
-      */
+       */
     `;
 			const result = minifyJs(input);
 			expect(result).toContain("@param");
@@ -199,14 +201,14 @@ describe("when testing for minifiers utilities with no logging side-effects", ()
       /**
        * This async function is awesome.
        * @async
-      */
+       */
       function greet(name) {
         return 'Hello, ' + name;
       }
 
       /**
        * This is not an important comment.
-      */
+       */
     `;
 			const result = minifyJs(input);
 			expect(result).not.toContain("awesome");
@@ -360,7 +362,7 @@ describe("when testing for minifiers utilities with no logging side-effects", ()
        * @description Custom hook for fetching data
        * @param {string} url - The URL to fetch from
        * @returns {Object} The fetched data and loading state
-      */
+       */
       function useFetch(url) {
         const [data, setData] = useState(null);
         const [loading, setLoading] = useState(true);


### PR DESCRIPTION
Updated JSDoc block generation to ensure a space precedes the closing '*/' for consistent formatting. Adjusted related tests and regex patterns to allow optional leading spaces before the closing delimiter.