### PR TITLE
fix: ensure space before closing JSDoc delimiter - take 2

### DIFF
--- a/packages/comments/src/__tests__/lib.test.ts
+++ b/packages/comments/src/__tests__/lib.test.ts
@@ -282,4 +282,30 @@ describe("parseAndTransformComments", () => {
 		// already).
 		expect(out.match(/merged\./)).toBeNull();
 	});
+
+	it("keeps a space before closing delimiter for complex multi-paragraph example", () => {
+		const input = [
+			"/**",
+			" * Extract the average from a list of numbers.",
+			" *",
+			" * @example",
+			" * ```js",
+			" * const res = extractAverage({ data: [11, 22, 33, 44] });",
+			" * console.log(res); // 27.5 -> (11 + 22 + 33 + 44) / 4",
+			" * ```",
+			" *",
+			" * Any value that is not a number or is less than 0 will be ignored.",
+			" *",
+			" * A formatter function can be passed to format the output. If no formatter is",
+			" * provided, the default behavior is to cast the number to the generic Output",
+			" * type.",
+			" *",
+			" */",
+		].join("\n");
+		const out = parseAndTransformComments(input, baseOpts).transformed;
+		// Closing line should contain a leading space before */ (style consistency)
+		expect(/\n \*\/$/.test(out)).toBe(true);
+		// Should not regress by emitting no-space variant
+		expect(/\n\*\/$/.test(out)).toBe(false);
+	});
 });

--- a/packages/comments/src/lib.ts
+++ b/packages/comments/src/lib.ts
@@ -211,7 +211,8 @@ function buildJsDoc(indent: string, rawBody: string, width: number): string {
 			}
 			out.push(prefix + normalizeNote(trimmed));
 		}
-		return `${indent}/**\n${out.join("\n")}\n${indent}*/`;
+		// Consistent style: space before closing */
+		return `${indent}/**\n${out.join("\n")}\n${indent} */`;
 	}
 
 	function flush(): void {


### PR DESCRIPTION
Updated buildJsDoc to consistently add a space before the closing '*/' in JSDoc comments for style consistency. Added a test to verify this behavior for complex multi-paragraph examples.