### PR TITLE
fix: remove trailing space on blank lines in code fences

### DIFF
--- a/packages/comments/src/__tests__/lib.test.ts
+++ b/packages/comments/src/__tests__/lib.test.ts
@@ -308,4 +308,29 @@ describe("parseAndTransformComments", () => {
 		// Should not regress by emitting no-space variant
 		expect(/\n\*\/$/.test(out)).toBe(false);
 	});
+
+	it("does not add trailing space on blank '*' lines inside code fences", () => {
+		const input = [
+			"/**",
+			" * Function to format a number with commas as thousands separators.",
+			" *",
+			" * @example",
+			" * ```js",
+			" * const formattedNumber = numberFormatter.format(1000);",
+			' * console.log(formattedNumber); // "1,000"',
+			" *", // blank line inside fence we want ' *' (no trailing space)
+			" * const roundedNumber = numberFormatter.format(1234.56);",
+			' * console.log(roundedNumber); // "1,235"',
+			" * ```",
+			" *",
+			" */",
+		].join("\n");
+		const out = parseAndTransformComments(input, baseOpts).transformed;
+		// Collect lines that are just star forms.
+		const starLines = out.split(/\n/).filter((l) => /^ \* ?$/.test(l));
+		// None of them should have a trailing space after the star.
+		for (const l of starLines) {
+			expect(l).toBe(" *");
+		}
+	});
 });

--- a/packages/comments/src/lib.ts
+++ b/packages/comments/src/lib.ts
@@ -237,7 +237,14 @@ function buildJsDoc(indent: string, rawBody: string, width: number): string {
 			continue;
 		}
 		if (inFence) {
-			out.push(prefix + trimmed);
+			// Inside a code fence we preserve content verbatim, but for a blank line
+			// we still prefer the canonical ' *' (no trailing space after the star)
+			// instead of ' * '.
+			if (trimmed === "") {
+				out.push(prefix.trimEnd());
+			} else {
+				out.push(prefix + trimmed);
+			}
 			continue;
 		}
 		if (


### PR DESCRIPTION
Ensures blank '*' lines inside code fences in JSDoc comments do not have a trailing space after the star. Adds a test to verify the correct formatting.