### PR TITLE
fix: update workspace dependencies to use wildcard

### DIFF
--- a/packages/comments/package.json
+++ b/packages/comments/package.json
@@ -28,9 +28,9 @@
 		"watch": "swc --strip-leading-paths --watch --out-dir dist src"
 	},
 	"dependencies": {
-		"@node-cli/logger": "workspace:../logger",
-		"@node-cli/parser": "workspace:../parser",
-		"@node-cli/utilities": "workspace:../utilities",
+		"@node-cli/logger": "workspace:*",
+		"@node-cli/parser": "workspace:*",
+		"@node-cli/utilities": "workspace:*",
 		"micromatch": "4.0.8"
 	},
 	"publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,13 +76,13 @@ importers:
   packages/comments:
     dependencies:
       '@node-cli/logger':
-        specifier: workspace:../logger
+        specifier: workspace:*
         version: link:../logger
       '@node-cli/parser':
-        specifier: workspace:../parser
+        specifier: workspace:*
         version: link:../parser
       '@node-cli/utilities':
-        specifier: workspace:../utilities
+        specifier: workspace:*
         version: link:../utilities
       micromatch:
         specifier: 4.0.8


### PR DESCRIPTION
Changed @node-cli/logger, @node-cli/parser, and @node-cli/utilities dependencies in comments package to use 'workspace:*' for improved flexibility and compatibility with workspace version resolution.