### PR TITLE
fix: lower threshold for merging line comments to JSDoc

### DIFF
--- a/packages/comments/src/__tests__/lib.test.ts
+++ b/packages/comments/src/__tests__/lib.test.ts
@@ -283,6 +283,26 @@ describe("parseAndTransformComments", () => {
 		expect(out.match(/merged\./)).toBeNull();
 	});
 
+	it("merges a 3-line explanatory // group after a statement into JSDoc (threshold lowered)", () => {
+		const src = [
+			"const value = compute();",
+			"// First explanatory line that starts with a capital",
+			"// second line continues the explanation",
+			"// third line completes it",
+			"next();",
+		].join("\n");
+		const out = parseAndTransformComments(src, {
+			width: 120,
+			wrapLineComments: true,
+			mergeLineComments: true,
+		}).transformed;
+		// The 3-line group should have been converted to a JSDoc block.
+		expect(/compute\(\);\n\/\*\*/.test(out)).toBe(true);
+		// Ensure original lines no longer start with // (inside block now) and period appended once.
+		expect(out).toMatch(/First explanatory line that starts with a capital/);
+		expect(out).not.toMatch(/third line completes it\n\/\//); // no stray // after
+	});
+
 	it("keeps a space before closing delimiter for complex multi-paragraph example", () => {
 		const input = [
 			"/**",

--- a/packages/comments/src/lib.ts
+++ b/packages/comments/src/lib.ts
@@ -337,9 +337,11 @@ function buildJsDoc(indent: string, rawBody: string, width: number): string {
 		para.push(trimmed);
 	}
 	flush();
-	// Style: ensure a space precedes the closing */ for consistency with blocks
-	// generated elsewhere in this tool (merged line comment groups). Previously
-	// we emitted `${indent}*/` which produced an off-by-one visual alignment.
+	/**
+	 * Style: ensure a space precedes the closing *\/ for consistency with blocks
+	 * generated elsewhere in this tool (merged line comment groups). Previously we
+	 * emitted `${indent}*\/` which produced an off-by-one visual alignment.
+	 */
 	return `${indent}/**\n${out.join("\n")}\n${indent} */`;
 }
 
@@ -490,8 +492,8 @@ function mergeLineCommentGroups(content: string): {
 			}
 			collected.push(body.trim());
 		}
-		if (collected.length < 4) {
-			return false; // require minimum size
+		if (collected.length < 3) {
+			return false; // lowered threshold from 4 -> 3 to permit shorter explanatory groups
 		}
 		if (!/^[A-Z]/.test(collected[0])) {
 			return false; // start with capitalized sentence
@@ -507,9 +509,11 @@ function mergeLineCommentGroups(content: string): {
 			const prev = i > 0 ? lines[i - 1] : "";
 			const prevTrim = prev.trim();
 			let contextEligible = prevTrim === "" || /[{}]$/.test(prevTrim);
-			// Heuristic: also allow large explanatory group after a statement ending
-			// with ';' when it qualifies as explanatory so it can be elevated to a
-			// block comment rather than remaining a run of // lines.
+			/**
+			 * Heuristic: also allow large explanatory group after a statement ending
+			 * with ';' when it qualifies as explanatory so it can be elevated to a block
+			 * comment rather than remaining a run of // lines.
+			 */
 			if (
 				!contextEligible &&
 				/;\s*$/.test(prevTrim) &&


### PR DESCRIPTION
Reduced the minimum required lines for merging explanatory line comment groups into JSDoc blocks from 4 to 3. Updated tests to verify the new behavior and improved code comments for clarity.