### PR TITLE
fix: improve merging of line comments after comma-ending lines

### DIFF
--- a/packages/comments/src/lib.ts
+++ b/packages/comments/src/lib.ts
@@ -553,7 +553,7 @@ function mergeLineCommentGroups(content: string): {
 		if (/^\s*\/\//.test(lines[i]) && !/^\s*\/\/\//.test(lines[i])) {
 			const prev = i > 0 ? lines[i - 1] : "";
 			const prevTrim = prev.trim();
-			let contextEligible = prevTrim === "" || /[{}]$/.test(prevTrim);
+			let contextEligible = prevTrim === "" || /[{}\]),;]$/.test(prevTrim);
 			/**
 			 * Heuristic: also allow large explanatory group after a statement ending
 			 * with ';' when it qualifies as explanatory so it can be elevated to a block


### PR DESCRIPTION
Enhanced the mergeLineCommentGroups function to recognize additional contexts (such as lines ending with ',', ')', ']', or ';') for merging consecutive line comments into JSDoc blocks. Added tests to verify correct merging behavior after object, array, and function blocks, and ensured single line comments are not merged when context is not eligible.