### PR TITLE
feat(bundlesize): add support for subgroup headers in bundle size rep…

### DIFF
--- a/packages/bundlesize/README.md
+++ b/packages/bundlesize/README.md
@@ -184,6 +184,64 @@ export default {
 };
 ```
 
+#### Report with subgroup headers (multiple tables)
+
+You can interleave header objects inside the `sizes` array to break the report output into multiple markdown tables. Each header object must contain a `header` property (any markdown heading is allowed). A sub-bundle total line will be printed after each group along with its diff to previous stats (if available), followed by the overall bundle size and status at the end.
+
+```js
+export default {
+  report: {
+    header: "## Bundle Size With Groups",
+    previous: "stats/previous.json",
+    current: "stats/current.json"
+  },
+  sizes: [
+    { header: "### Core" },
+    { path: "dist/core.js", limit: "20 kB" },
+    { path: "dist/core-extra.js", limit: "10 kB" },
+    { header: "### Widgets" },
+    { path: "dist/widget-a.js", limit: "15 kB" },
+    { path: "dist/widget-b.js", limit: "15 kB" }
+  ]
+};
+```
+
+Example output:
+
+```
+## Bundle Size With Groups
+
+### Core
+
+| Status | File | Size (Gzip) | Limits |
+| --- | --- | --- | --- |
+| ✅ | core.js | 12.34 KB (-1.2 KB -8.80%) | 20 kB |
+| ✅ | core-extra.js | 3.21 KB | 10 kB |
+
+Sub-bundle size: 15.55 KB (-1.2 KB -7.17%)
+
+
+### Widgets
+
+| Status | File | Size (Gzip) | Limits |
+| --- | --- | --- | --- |
+| ✅ | widget-a.js | 5.00 KB (+500 B +10.84%) | 15 kB |
+| ✅ | widget-b.js | 4.50 KB | 15 kB |
+
+Sub-bundle size: 9.50 KB (+500 B +5.56%)
+
+
+Overall bundle size: 25.05 KB (-700 B -2.72%)
+Overall status: ✅
+```
+
+Notes:
+
+- If no header objects are present, the legacy single-table format is used (backwards compatible).
+- Headers are rendered in the order they appear in `sizes`.
+- Only size entries that resolve in the current stats are printed; missing ones are skipped silently.
+- Sub-bundle diff lines only show percentage / size diff when previous stats for at least one file in the subgroup exist.
+
 ## Usage
 
 ### Print the stats at the command line

--- a/packages/bundlesize/src/__tests__/fixtures/configuration/with-groups.js
+++ b/packages/bundlesize/src/__tests__/fixtures/configuration/with-groups.js
@@ -1,0 +1,14 @@
+export default {
+	report: {
+		previous: "../stats/previous.json",
+		current: "../stats/current.json",
+		header: "## Bundle Size With Groups",
+	},
+	sizes: [
+		{ header: "### Group A" },
+		{ path: "data/file.txt", limit: "1.5 kB" },
+		{ path: "data/file.zip", limit: "1.5 kB" },
+		{ header: "### Group B" },
+		{ path: "data/file-no-change", limit: "1.5 kB" },
+	],
+};

--- a/packages/bundlesize/src/__tests__/getRawStats.test.ts
+++ b/packages/bundlesize/src/__tests__/getRawStats.test.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import kleur from "kleur";
+import { describe, expect, it } from "vitest";
+
 import { getRawStats } from "../getRawStats.js";
 import { IGNORE } from "../utilities.js";
 

--- a/packages/bundlesize/src/__tests__/reportStats.test.ts
+++ b/packages/bundlesize/src/__tests__/reportStats.test.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import kleur from "kleur";
+import { describe, expect, it } from "vitest";
+
 import { reportStats } from "../reportStats.js";
 import { STDOUT } from "../utilities.js";
 
@@ -18,6 +20,48 @@ describe("when testing for reportStats with errors", () => {
 			exitCode: 1,
 			exitMessage: "Please provide a configuration file",
 			outputFile: "",
+		});
+	});
+
+	it("should report stats with subgroup headers", async () => {
+		const result = await reportStats({
+			flags: {
+				configuration: path.join(
+					__dirname,
+					"fixtures/configuration/with-groups.js",
+				),
+			},
+		});
+
+		expect(result).toEqual({
+			data: `
+## Bundle Size With Groups
+
+### Group A
+
+| Status | File | Size (Gzip) | Limits |
+| --- | --- | --- | --- |
+| ✅ | file.txt | 19.43 KB (-78.5 KB -80.16%) | 1.5 kB |
+| ✅ | file.zip | 19.53 KB (+19.51 KB +105,157.89%) | 1.5 kB |
+
+Sub-bundle size: 38.96 KB (-58.99 KB -60.22%)
+
+
+### Group B
+
+| Status | File | Size (Gzip) | Limits |
+| --- | --- | --- | --- |
+| ✅ | file-no-change | 19.53 KB | 1.5 kB |
+
+Sub-bundle size: 19.53 KB
+
+
+Overall bundle size: 58.49 KB (-58.99 KB -50.21%)
+Overall status: ✅
+`,
+			exitCode: 0,
+			exitMessage: "",
+			outputFile: STDOUT,
 		});
 	});
 

--- a/packages/bundlesize/src/__tests__/utilities.test.ts
+++ b/packages/bundlesize/src/__tests__/utilities.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import {
 	addMDrow,
 	formatFooter,

--- a/packages/bundlesize/src/reportStats.ts
+++ b/packages/bundlesize/src/reportStats.ts
@@ -14,11 +14,14 @@ import {
 type ReportConfiguration = {
 	current: string;
 	previous: string;
-
 	header?: string;
 	footer?: (arguments_: FooterProperties) => string;
 	columns?: { [key: string]: string }[];
 };
+
+type SizesConfiguration = Array<
+	{ header: string } | { path: string; limit: string; alias?: string }
+>;
 
 type ReportCompare = {
 	data: string;
@@ -34,30 +37,27 @@ export const reportStats = async ({ flags }): Promise<ReportCompare> => {
 		outputFile: "",
 		data: "",
 	};
+
 	let previousStats, previousVersion: string;
 	const isValidConfigResult = validateConfigurationFile(flags.configuration);
 	if (isValidConfigResult.exitMessage !== "") {
-		return {
-			...result,
-			...isValidConfigResult,
-		};
+		return { ...result, ...isValidConfigResult };
 	}
+
 	const configurationFile = isValidConfigResult.data;
 	const outputFile = getOutputFile(flags.output);
 	result.outputFile = outputFile;
 
-	const configuration: { report: ReportConfiguration } = await import(
-		configurationFile
-	).then((m) => m.default);
+	const configuration: {
+		report: ReportConfiguration;
+		sizes?: SizesConfiguration;
+	} = await import(configurationFile).then((m) => m.default);
 
 	const currentStats = readJSONFile(
 		join(dirname(configurationFile), configuration.report.current),
 	);
 	if (currentStats.exitMessage !== "") {
-		return {
-			...result,
-			...currentStats,
-		};
+		return { ...result, ...currentStats };
 	}
 
 	try {
@@ -65,15 +65,13 @@ export const reportStats = async ({ flags }): Promise<ReportCompare> => {
 			join(dirname(configurationFile), configuration.report.previous),
 		);
 		if (previousStats.exitMessage !== "") {
-			return {
-				...result,
-				...previousStats,
-			};
+			return { ...result, ...previousStats };
 		}
 		previousVersion = getMostRecentVersion(previousStats.data);
 	} catch {
-		// nothing to declare officer.
+		// no previous stats available
 	}
+
 	const currentVersion = getMostRecentVersion(currentStats.data);
 
 	let limitReached = false;
@@ -89,34 +87,118 @@ export const reportStats = async ({ flags }): Promise<ReportCompare> => {
 		{ limits: "Limits" },
 	];
 
-	const rowsMD = [];
-	rowsMD.push(addMDrow({ type: "header", columns }));
+	const rowsMD: string[] = [];
+	const hasGroupHeaders = Boolean(
+		configuration.sizes?.some((entry: any) => entry.header !== undefined),
+	);
+	if (!hasGroupHeaders) {
+		rowsMD.push(addMDrow({ type: "header", columns }));
+	}
 
-	for (const key of Object.keys(currentStats.data[currentVersion])) {
+	// Build ordered keys based on configuration.sizes if present
+	const orderedKeys: Array<{
+		type: "header" | "item";
+		value: string;
+		header?: string;
+	}> = [];
+	if (configuration.sizes && Array.isArray(configuration.sizes)) {
+		for (const entry of configuration.sizes) {
+			if ((entry as any).header) {
+				orderedKeys.push({
+					type: "header",
+					value: "",
+					header: (entry as any).header,
+				});
+				continue;
+			}
+			const sizeEntry = entry as {
+				path: string;
+				limit: string;
+				alias?: string;
+			};
+			if (
+				sizeEntry.alias &&
+				currentStats.data[currentVersion][sizeEntry.alias]
+			) {
+				orderedKeys.push({ type: "item", value: sizeEntry.alias });
+			} else if (currentStats.data[currentVersion][sizeEntry.path]) {
+				orderedKeys.push({ type: "item", value: sizeEntry.path });
+			}
+		}
+	}
+
+	if (orderedKeys.length === 0) {
+		for (const key of Object.keys(currentStats.data[currentVersion])) {
+			orderedKeys.push({ type: "item", value: key });
+		}
+	}
+
+	let subGroupAccumulatedSize = 0;
+	let subGroupAccumulatedPrevSize = 0;
+	let hasSubGroup = false;
+	const flushSubGroup = () => {
+		if (!hasSubGroup) {
+			return;
+		}
+		const diff = subGroupAccumulatedSize - subGroupAccumulatedPrevSize;
+		let diffString = "";
+		if (diff !== 0 && subGroupAccumulatedPrevSize !== 0) {
+			const sign = diff > 0 ? "+" : "-";
+			diffString = ` (${sign}${bytes(Math.abs(diff), { unitSeparator: " " })} ${percentFormatter(
+				diff / subGroupAccumulatedPrevSize,
+			)})`;
+		}
+		if (hasGroupHeaders) {
+			rowsMD.push(
+				`\nSub-bundle size: ${bytes(subGroupAccumulatedSize, {
+					unitSeparator: " ",
+				})}${diffString}`,
+				"",
+			);
+		}
+		subGroupAccumulatedSize = 0;
+		subGroupAccumulatedPrevSize = 0;
+		hasSubGroup = false;
+	};
+
+	for (const entry of orderedKeys) {
+		if (entry.type === "header") {
+			flushSubGroup();
+			rowsMD.push("", entry.header as string, "");
+			rowsMD.push(addMDrow({ type: "header", columns }));
+			continue;
+		}
+		const key = entry.value;
 		const item = currentStats.data[currentVersion][key];
+		if (!item) {
+			continue;
+		}
 		const name = basename(key);
 		if (!item.passed) {
 			limitReached = true;
 		}
 
 		let diffString = "";
+		let previousFileSizeGzip = 0;
 		if (previousStats && previousVersion) {
 			const previousFileStats =
 				previousStats.data[previousVersion] &&
 				previousStats.data[previousVersion][key];
-			const previousFileSizeGzip = previousFileStats?.fileSizeGzip || 0;
+			previousFileSizeGzip = previousFileStats?.fileSizeGzip || 0;
 			const diff = item.fileSizeGzip - previousFileSizeGzip;
-
 			overallDiff += diff;
 			diffString =
 				diff === 0 || diff === item.fileSizeGzip
 					? ""
-					: ` (${diff > 0 ? "+" : "-"}${bytes(Math.abs(diff), {
-							unitSeparator: " ",
-						})} ${percentFormatter(diff / previousFileSizeGzip)})`;
+					: ` (${diff > 0 ? "+" : "-"}${bytes(Math.abs(diff), { unitSeparator: " " })} ${percentFormatter(
+							previousFileSizeGzip === 0 ? 0 : diff / previousFileSizeGzip,
+						)})`;
 		}
 
 		totalGzipSize += item.fileSizeGzip;
+		subGroupAccumulatedSize += item.fileSizeGzip;
+		subGroupAccumulatedPrevSize += previousFileSizeGzip;
+		hasSubGroup = true;
 
 		rowsMD.push(
 			addMDrow({
@@ -131,22 +213,18 @@ export const reportStats = async ({ flags }): Promise<ReportCompare> => {
 		);
 	}
 
+	flushSubGroup();
+
 	const template = `
 ${headerString}
 ${rowsMD.join("\n")}
 
-${footerFormatter({
-	limitReached,
-	overallDiff,
-	totalGzipSize,
-})}
+${footerFormatter({ limitReached, overallDiff, totalGzipSize })}
 `;
 
 	if (limitReached) {
 		result.exitCode = 1;
 	}
-
 	result.data = template;
-
 	return result;
 };


### PR DESCRIPTION
…orts

Introduces the ability to define subgroup headers in the `sizes` array of the configuration, allowing bundle size reports to be split into multiple markdown tables with sub-bundle totals and diffs. Updates documentation, tests, and implementation to support this feature while maintaining backward compatibility with the legacy single-table format.